### PR TITLE
feat: Implement quantized matmul_reduce_scatter operator

### DIFF
--- a/examples/02_matmul_reduce_scatter/CMakeLists.txt
+++ b/examples/02_matmul_reduce_scatter/CMakeLists.txt
@@ -2,3 +2,8 @@ catcoc_example_add_executable(
     02_matmul_reduce_scatter
     SOURCES matmul_reduce_scatter.cpp
 )
+
+catcoc_example_add_executable(
+    02_quant_matmul_reduce_scatter
+    SOURCES quant_matmul_reduce_scatter.cpp
+)

--- a/examples/02_matmul_reduce_scatter/quant_matmul_reduce_scatter.cpp
+++ b/examples/02_matmul_reduce_scatter/quant_matmul_reduce_scatter.cpp
@@ -1,0 +1,332 @@
+#include <acl/acl.h>
+
+#include <iostream>
+#include <vector>
+#include <cstring>
+
+// from catlass
+#include "catlass/catlass.hpp"
+#include "catlass/arch/arch.hpp"
+#include "catlass/epilogue/tile/tile_copy.hpp"
+#include "catlass/epilogue/tile/tile_swizzle.hpp"
+#include "catlass/gemm/block/block_mmad.hpp"
+#include "catlass/gemm/block/block_swizzle.hpp"
+#include "catlass/gemm/dispatch_policy.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+#include "catlass/layout/layout.hpp"
+
+// shmem_host
+#include "host/shmem_host_def.h"
+#include "host/shmem_host_heap.h"
+#include "host/shmem_host_init.h"
+#include "host/shmem_host_rma.h"
+#include "host/shmem_host_team.h"
+
+// utils
+#include "utils/utils.h"
+
+#include "catcoc/catcoc.hpp"
+#include "catcoc/comm_epilogue/comm_dispatch_policy.hpp"
+#include "catcoc/comm_epilogue/block/comm_block_epilogue.hpp"
+#include "catcoc/comm_epilogue/block/comm_block_swizzle.hpp"
+#include "catcoc/comm_epilogue/tile/tile_remote_copy.hpp"
+#include "catcoc/detail/remote_copy_type.hpp"
+#include "catcoc/dgemm/kernel/quant_matmul_reduce_scatter.hpp"
+
+static uint32_t gNpuNum = 8;
+static uint64_t gNpuMallocSpace = 1024UL * 1024UL * 1024;
+
+using namespace AscendC;
+using namespace Catcoc;
+
+constexpr uint32_t BLOCK_NUM = 20;
+constexpr int32_t BLOCK_SIZE_16 = 16;
+
+using LayoutA = Catlass::layout::RowMajor;
+using LayoutB = Catlass::layout::RowMajor;
+using LayoutC = Catlass::layout::RowMajor;
+using LayoutD = Catlass::layout::RowMajor;
+
+CATLASS_GLOBAL
+void ShmemQuantMatmulReduceScatter(
+    uint64_t fftsAddr,
+    GM_ADDR x1, GM_ADDR x2, GM_ADDR scale_x1, GM_ADDR scale_x2, GM_ADDR bias,
+    GM_ADDR c_accum, GM_ADDR d_out, GM_ADDR symmetricPtr,
+    uint32_t m, uint32_t n, uint32_t k
+)
+{
+    // Set FFTS address
+    AscendC::SetSyncBaseAddr(fftsAddr);
+
+    // Define ArchTag
+    using ArchTag = Catlass::Arch::AtlasA2;
+
+    Catlass::GemmCoord problemShape{m, n, k};
+
+    // Prepare comm address
+    uint32_t rank = shmem_my_pe();
+    uint32_t rankSize = shmem_n_pes();
+
+    // Define layouts
+    Catlass::layout::RowMajor layoutA{m, k, k};
+    Catlass::layout::RowMajor layoutB{k, n, n};
+    Catlass::layout::RowMajor layoutC_accum{m / rankSize, n, n};
+    Catlass::layout::RowMajor layoutD_out{m / rankSize, n, n};
+    Catlass::layout::RowMajor layout_scale_x1{m, 1, 1};
+    Catlass::layout::RowMajor layout_scale_x2{n, 1, 1};
+    Catlass::layout::RowMajor layout_bias{n, 1, 1};
+
+    // Define types for BlockMmad
+    using AType = Catlass::Gemm::GemmType<int8_t, LayoutA>;
+    using BType = Catlass::Gemm::GemmType<int8_t, LayoutB>;
+    using CType = Catlass::Gemm::GemmType<int32_t, LayoutC>; // Accumulator is int32
+
+    constexpr bool enableUnitFlag = true;
+    using MmadDispatchPolicy = Catlass::Gemm::MmadAtlasA2Pingpong<enableUnitFlag>;
+    using L1TileShape = Catlass::GemmShape<128, 256, 256>;
+    using L0TileShape = Catlass::GemmShape<128, 256, 64>;
+    using BlockMmad = Catlass::Gemm::Block::BlockMmad<MmadDispatchPolicy,
+        L1TileShape, L0TileShape, AType, BType, CType>;
+
+    // Define types for ReduceScatter Epilogue (int32 -> int32)
+    using ReduceScatterCType = CType;
+    using ReduceScatterDType = CType;
+
+    using BlockScheduler = typename Catlass::Gemm::Block::GemmIdentityBlockSwizzle<7, 1>;
+    using CommBlockScheduler = CommEpilogue::Block::BlockCommSwizzle<0>;
+
+    using CopyDirect = Catcoc::detail::CopyDirect;
+    using TileRemoteCopy = CommEpilogue::Tile::TileRemoteCopy<ArchTag, ReduceScatterCType, ReduceScatterDType, CopyDirect::Get>;
+    using TileScheduler = Catlass::Epilogue::Tile::EpilogueIdentityTileSwizzle;
+
+    using CommBlockShape = Catlass::MatrixShape<64, 256>;
+    using CommCoreSplit = Catlass::MatrixShape<20, 1>;
+
+    constexpr uint32_t ubStages = 2;
+    using ReduceScatterTileShape = Catlass::MatrixShape<32, 256>;
+    using ReduceScatterDispatch = CommEpilogue::EpilogueAtlasA2CommToLocalMem<ubStages,
+        Catcoc::detail::CopyMode::Scatter>;
+    using BlockEpilogueReduceScatter = CommEpilogue::Block::CommBlockEpilogue<
+        ReduceScatterDispatch,
+        ReduceScatterCType, ReduceScatterDType,
+        CommCoreSplit,
+        CommBlockShape,
+        ReduceScatterTileShape, TileRemoteCopy, TileScheduler,
+        BlockScheduler
+    >;
+
+    constexpr uint32_t workspaceStages = 2;
+    constexpr uint32_t commInterval = 10;
+    using QuantMatmulReduceScatterKernel = DGemm::Kernel::QuantMatmulReduceScatter<
+        BlockMmad,
+        BlockEpilogueReduceScatter,
+        BlockScheduler,
+        CommBlockScheduler,
+        workspaceStages
+    >;
+    Catlass::GemmCoord problemShapeInRank = problemShape / Catlass::MakeCoord<uint32_t>(rankSize, 1, 1);
+    BlockScheduler matmulBlockScheduler(problemShapeInRank, Catlass::MakeCoord(L1TileShape::M, L1TileShape::N));
+
+    Catlass::layout::RowMajor layoutPeerMemStore{
+        L1TileShape::M * commInterval * BLOCK_NUM * workspaceStages, L1TileShape::N,
+        L1TileShape::N
+    };
+
+    typename BlockEpilogueReduceScatter::Params reduceScatterParams{
+        reinterpret_cast<__gm__ int32_t *>(symmetricPtr),
+        layoutPeerMemStore,
+        matmulBlockScheduler
+    };
+
+    // Prepare params
+    typename QuantMatmulReduceScatterKernel::Params params{
+        problemShape,
+        rank, rankSize,
+        x1, layoutA,
+        x2, layoutB,
+        symmetricPtr,
+        reduceScatterParams,
+        c_accum, layoutC_accum,
+        d_out, layoutD_out,
+        scale_x1, layout_scale_x1,
+        scale_x2, layout_scale_x2,
+        bias, layout_bias,
+        commInterval
+    };
+
+    // Call kernel
+    QuantMatmulReduceScatterKernel matmulCommKernel;
+    matmulCommKernel(params);
+}
+
+struct Options {
+    static constexpr auto helper = "Usage: matmul_allreduce m n k transA transB\n";
+
+    int rankSize;
+    int rankId;
+    std::string ipPort{};
+    uint32_t m{0};
+    uint32_t n{0};
+    uint32_t k{0};
+    std::vector<int> deviceIdList{};
+
+    int Parse(int argc, char **argv)
+    {
+        enum ArgsIndex {
+            RANK_SIZE_INDEX = 1,
+            RANK_ID_INDEX,
+            IP_PORT_INDEX,
+            M_INDEX,
+            N_INDEX,
+            K_INDEX,
+            DEVICE_LIST_INDEX,
+            INDEX_MAX
+        };
+
+        if (argc > INDEX_MAX) {
+            printf(helper);
+            return -1;
+        }
+
+        rankSize = std::atoi(argv[RANK_SIZE_INDEX]);
+        rankId = std::atoi(argv[RANK_ID_INDEX]);
+        ipPort = argv[IP_PORT_INDEX];
+        m = std::atoi(argv[M_INDEX]);
+        n = std::atoi(argv[N_INDEX]);
+        k = std::atoi(argv[K_INDEX]);
+        if (argc > DEVICE_LIST_INDEX) {
+            char *idListStr = argv[DEVICE_LIST_INDEX];
+            for (char *idToken = std::strtok(idListStr, ","); idToken; idToken = std::strtok(nullptr, ",")) {
+                deviceIdList.push_back(std::atoi(idToken));
+            }
+        } else {
+            for (int i = 0; i < rankSize; ++i) {
+                deviceIdList.push_back(i);
+            }
+        }
+        return 0;
+    }
+};
+
+int main(int argc, char **argv)
+{
+    int status = SHMEM_SUCCESS;
+    Options options;
+    options.Parse(argc, argv);
+    int rankSize = options.rankSize;
+    int rankId = options.rankId;
+    std::string ipPort = options.ipPort;
+    uint32_t m = options.m;
+    uint32_t n = options.n;
+    uint32_t k = options.k;
+    int32_t deviceId = options.deviceIdList[rankId];
+
+    std::cout << "[TEST] input rank_size: " << rankSize << " rank_id:" << rankId << " input_ip: " << ipPort << "\n";
+
+    aclrtStream stream = nullptr;
+    ACL_CHECK(aclInit(nullptr));
+    ACL_CHECK(aclrtSetDevice(deviceId));
+    ACL_CHECK(aclrtCreateStream(&stream));
+    shmem_init_attr_t *attributes;
+    status = shmem_set_attr(rankId, rankSize, gNpuMallocSpace, ipPort.c_str(), &attributes);
+    status = shmem_init_attr(attributes);
+    status = shmem_init_status();
+
+    // Prepare FFTS address
+    uint64_t fftsAddr{0};
+    uint32_t fftsLen{0};
+    RT_CHECK(rtGetC2cCtrlAddr(&fftsAddr, &fftsLen));
+
+    // Memory sizes
+    size_t x1Size = static_cast<size_t>(m) * k * sizeof(int8_t);
+    size_t x2Size = static_cast<size_t>(k) * n * sizeof(int8_t);
+    size_t scaleX1Size = static_cast<size_t>(m) * sizeof(float);
+    size_t scaleX2Size = static_cast<size_t>(n) * sizeof(float);
+    size_t biasSize = static_cast<size_t>(n) * sizeof(int32_t);
+    size_t cAccumSize = static_cast<size_t>(m) * n * sizeof(int32_t) / rankSize;
+    size_t dOutSize = static_cast<size_t>(m) * n * sizeof(bfloat16) / rankSize;
+
+    // Allocate and copy x1
+    uint8_t *x1Device, *x1Host;
+    ACL_CHECK(aclrtMalloc((void **)(&x1Device), x1Size, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMallocHost((void **)(&x1Host), x1Size));
+    ReadFile("./output/x1_gm.bin", x1Host, x1Size);
+    ACL_CHECK(aclrtMemcpy(x1Device, x1Size, x1Host, x1Size, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    // Allocate and copy x2
+    uint8_t *x2Device, *x2Host;
+    ACL_CHECK(aclrtMalloc((void **)(&x2Device), x2Size, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMallocHost((void **)(&x2Host), x2Size));
+    ReadFile("./output/x2_gm.bin", x2Host, x2Size);
+    ACL_CHECK(aclrtMemcpy(x2Device, x2Size, x2Host, x2Size, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    // Allocate and copy scale_x1
+    uint8_t *scaleX1Device, *scaleX1Host;
+    ACL_CHECK(aclrtMalloc((void **)(&scaleX1Device), scaleX1Size, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMallocHost((void **)(&scaleX1Host), scaleX1Size));
+    ReadFile("./output/scale_x1_gm.bin", scaleX1Host, scaleX1Size);
+    ACL_CHECK(aclrtMemcpy(scaleX1Device, scaleX1Size, scaleX1Host, scaleX1Size, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    // Allocate and copy scale_x2
+    uint8_t *scaleX2Device, *scaleX2Host;
+    ACL_CHECK(aclrtMalloc((void **)(&scaleX2Device), scaleX2Size, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMallocHost((void **)(&scaleX2Host), scaleX2Size));
+    ReadFile("./output/scale_x2_gm.bin", scaleX2Host, scaleX2Size);
+    ACL_CHECK(aclrtMemcpy(scaleX2Device, scaleX2Size, scaleX2Host, scaleX2Size, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    // Allocate and copy bias
+    uint8_t *biasDevice, *biasHost;
+    ACL_CHECK(aclrtMalloc((void **)(&biasDevice), biasSize, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMallocHost((void **)(&biasHost), biasSize));
+    ReadFile("./output/bias_gm.bin", biasHost, biasSize);
+    ACL_CHECK(aclrtMemcpy(biasDevice, biasSize, biasHost, biasSize, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    // Allocate intermediate and final output buffers
+    uint8_t *cAccumDevice;
+    ACL_CHECK(aclrtMalloc((void **)(&cAccumDevice), cAccumSize, ACL_MEM_MALLOC_HUGE_FIRST));
+    uint8_t *dOutDevice, *dOutHost;
+    ACL_CHECK(aclrtMalloc((void **)(&dOutDevice), dOutSize, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMallocHost((void **)(&dOutHost), dOutSize));
+
+    // Allocate shared memory workspace
+    void *symmPtr = shmem_malloc((204 * 1024 * 1024) * sizeof(int32_t));
+    uint8_t *symmetricPtr = (uint8_t *)symmPtr;
+
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+    for (int i = 0; i < 1; i++) {
+        ShmemQuantMatmulReduceScatter<<<BLOCK_NUM, nullptr, stream>>>(fftsAddr,
+            x1Device, x2Device, scaleX1Device, scaleX2Device, biasDevice,
+            cAccumDevice, dOutDevice, symmetricPtr, m, n, k);
+    }
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+
+    ACL_CHECK(aclrtMemcpy(dOutHost, dOutSize, dOutDevice, dOutSize, ACL_MEMCPY_DEVICE_TO_HOST));
+    WriteFile("./output/output.bin", dOutHost, dOutSize, options.rankId * dOutSize);
+    if (rankId == 0) {
+        std::printf("test finished\n");
+    }
+
+    shmem_free(symmPtr);
+
+    ACL_CHECK(aclrtFreeHost(x1Host));
+    ACL_CHECK(aclrtFreeHost(x2Host));
+    ACL_CHECK(aclrtFreeHost(scaleX1Host));
+    ACL_CHECK(aclrtFreeHost(scaleX2Host));
+    ACL_CHECK(aclrtFreeHost(biasHost));
+    ACL_CHECK(aclrtFreeHost(dOutHost));
+    ACL_CHECK(aclrtFree(x1Device));
+    ACL_CHECK(aclrtFree(x2Device));
+    ACL_CHECK(aclrtFree(scaleX1Device));
+    ACL_CHECK(aclrtFree(scaleX2Device));
+    ACL_CHECK(aclrtFree(biasDevice));
+    ACL_CHECK(aclrtFree(cAccumDevice));
+    ACL_CHECK(aclrtFree(dOutDevice));
+
+    std::cout << "[TEST] begin to exit...... rankId: " << rankId << std::endl;
+    status = shmem_finalize();
+    ACL_CHECK(aclrtDestroyStream(stream));
+    ACL_CHECK(aclrtResetDevice(deviceId));
+    ACL_CHECK(aclFinalize());
+
+    return 0;
+}

--- a/examples/02_matmul_reduce_scatter/scripts/run_quant.sh
+++ b/examples/02_matmul_reduce_scatter/scripts/run_quant.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# eg. bash run.sh 0,1      # 在 0/1 卡上运行，rank size = 2
+# eg. bash run.sh 1,3,5,7  # 在 1/3/5/6 卡上运行，rank size = 4
+
+CURRENT_DIR=$(pwd)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+PROJECT_ROOT=$( dirname $( dirname $(dirname "$SCRIPT_DIR")))
+UTILS_PATH=${PROJECT_ROOT}/examples/utils
+
+CSV_FILE="${SCRIPT_DIR}/test_shapes.csv"
+
+IFS=',' read -ra DEVICE_ID_LIST <<< "$1"
+RANK_SIZE=${#DEVICE_ID_LIST[@]}
+if [ $RANK_SIZE -gt 8 ]; then
+    echo "Rank size is illegal"
+    exit 1
+fi
+
+cd ${PROJECT_ROOT}/examples/02_matmul_reduce_scatter/
+EXEC_BIN=${PROJECT_ROOT}/build/bin/02_quant_matmul_reduce_scatter
+
+test_idx=0
+mkdir -p output
+tail -n +2 "$CSV_FILE" | while IFS=',' read -r M K N; do
+    let test_idx+=1
+    echo "Processing test case: M=${M}, K=${K}, N=${N}"
+
+    # Generate golden data
+    rm -rf output/*.bin
+    python3 ${UTILS_PATH}/gen_quant_data.py 2 1 ${RANK_SIZE} ${M} ${N} ${K} 0 0
+
+    # Set necessary parameters
+    IPPORT="tcp://127.0.0.1:4753${test_idx: -1}"
+
+    # Start Process
+    for (( rank_idx = 0; rank_idx < ${RANK_SIZE}; rank_idx = rank_idx + 1 )); do
+        ${EXEC_BIN} "$RANK_SIZE" "$rank_idx" "$IPPORT" "$M" "$N" "$K" "$1" &
+    done
+
+    # Wait until all process exit
+    wait
+
+    # Verify output
+    python3 ${UTILS_PATH}/verify_quant_result.py ./output/output.bin ./output/golden.bin 1 ${M} ${N} ${K}
+done
+
+cd ${CURRENT_DIR}

--- a/examples/utils/gen_quant_data.py
+++ b/examples/utils/gen_quant_data.py
@@ -1,0 +1,68 @@
+import torch
+
+from utils import CommType, DataType, tensor_to_file
+
+def gen_random_data(size, dtype):
+    if dtype == torch.float16 or dtype == torch.bfloat16 or dtype == torch.float32:
+        return torch.randn(size=size, dtype=dtype)
+    elif dtype == torch.int8:
+        return torch.randint(-16, 16, size=size, dtype=dtype)
+    else:
+        print(f"Invalid dtype: {dtype}.")
+        exit(1)
+
+def gen_golden_data():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('comm_type', type=CommType.from_str,
+                        choices=[CommType.MATMUL_ALLREDUCE, CommType.ALLGATHER_MATMUL, CommType.MATMUL_REDUCE_SCATTER])
+    parser.add_argument('out_dtype', type=DataType.from_str, choices=[DataType.FLOAT16, DataType.BF16])
+    parser.add_argument('rank_size', type=int)
+    parser.add_argument('m', type=int)
+    parser.add_argument('n', type=int)
+    parser.add_argument('k', type=int)
+    parser.add_argument('transA', type=int)
+    parser.add_argument('transB', type=int)
+    args = parser.parse_args()
+    M, N, K = args.m, args.n, args.k
+
+    # Generate quantized inputs
+    x1_gm = gen_random_data([M, K], dtype=torch.int8)
+    x2_gm = gen_random_data([K, N], dtype=torch.int8)
+    scale_x1_gm = torch.randn(M, dtype=torch.float32) * 0.01
+    scale_x2_gm = torch.randn(N, dtype=torch.float32) * 0.01
+    bias_gm = torch.zeros(N, dtype=torch.int32)
+    c_gm = torch.zeros((M // args.rank_size, N), dtype=args.out_dtype.torch_type)
+
+    # Calculate golden result
+    l0c_dtype = torch.float32
+    accumulator = torch.matmul(x1_gm.to(l0c_dtype), x2_gm.to(l0c_dtype))
+
+    dequantized = accumulator + bias_gm.to(l0c_dtype)
+
+    # Apply scales
+    # scale_x1 is per-token (per-row of A), scale_x2 is per-channel (per-column of B)
+    result_fp32 = dequantized * scale_x1_gm.unsqueeze(1).to(l0c_dtype) * scale_x2_gm.unsqueeze(0).to(l0c_dtype)
+
+    # The reduce-scatter operation sums the results from all ranks
+    golden = torch.zeros_like(result_fp32)
+    for _ in range(args.rank_size):
+        golden += result_fp32
+
+    golden = golden.to(args.out_dtype.torch_type)
+
+    if args.transA:
+        x1_gm = x1_gm.transpose(0, 1).contiguous()
+    if args.transB:
+        x2_gm = x2_gm.transpose(0, 1).contiguous()
+
+    tensor_to_file(x1_gm, "./output/x1_gm.bin")
+    tensor_to_file(x2_gm, "./output/x2_gm.bin")
+    tensor_to_file(scale_x1_gm, "./output/scale_x1_gm.bin")
+    tensor_to_file(scale_x2_gm, "./output/scale_x2_gm.bin")
+    tensor_to_file(bias_gm, "./output/bias_gm.bin")
+    tensor_to_file(c_gm, "./output/c_gm.bin") # This is a placeholder for the output buffer
+    tensor_to_file(golden, "./output/golden.bin")
+
+if __name__ == '__main__':
+    gen_golden_data()

--- a/examples/utils/verify_quant_result.py
+++ b/examples/utils/verify_quant_result.py
@@ -1,0 +1,149 @@
+import sys
+from enum import Enum
+import numpy as np
+import scipy
+import torch
+import logging
+
+from utils import DataType, tensor_from_file, get_rtol
+
+RED = "\033[31m"
+GREEN = "\033[32m"
+RESET = "\033[0m"
+
+class OpTypes(Enum):
+    NA = 0 # new standard is not available
+    MOVE = 1
+    RAND = 2
+    CAST = 3
+    COMPUTE_INTEGER = 4
+    COMPUTE_QUANT = 5
+    COMPUTE_FLOAT = 6
+    COMPUTE_FLOAT_HIGH_PRECISION = 7
+    VECTOR_FUSION = 8
+    CV_FUSION = 9
+
+def get_precision_and_eb_threshold(op_type, dtype, rtol: float = 2**(-8)):
+    precision_threshold = 0
+    eb_threshold = 0
+    if op_type in [OpTypes.MOVE, OpTypes.RAND, OpTypes.CAST, OpTypes.COMPUTE_INTEGER]:
+        pass
+    if op_type in [OpTypes.COMPUTE_QUANT]:
+        if dtype in [torch.int8]:
+            precision_threshold = 1
+    if op_type in [OpTypes.COMPUTE_QUANT, OpTypes.COMPUTE_FLOAT]:
+        if dtype in [torch.float16]:
+            precision_threshold = rtol
+            eb_threshold = 2**(-10)
+        if dtype in [torch.bfloat16]:
+            precision_threshold = rtol
+            eb_threshold = 2**(-7)
+        if dtype in [torch.float32]:
+            precision_threshold = rtol
+            eb_threshold = 2**(-14)
+    if op_type in [OpTypes.COMPUTE_FLOAT_HIGH_PRECISION]:
+        if dtype in [torch.float16]:
+            precision_threshold = 2**(-11)
+            eb_threshold = 2**(-10)
+        if dtype in [torch.bfloat16]:
+            precision_threshold = 2**(-8)
+            eb_threshold = 2**(-7)
+        if dtype in [torch.float32]:
+            precision_threshold = 2**(-14)
+            eb_threshold = 2**(-14)
+    if op_type in [OpTypes.VECTOR_FUSION]:
+        if dtype in [torch.float16]:
+            precision_threshold = 2**(-9)
+            eb_threshold = 2**(-10)
+        if dtype in [torch.bfloat16]:
+            precision_threshold = 2**(-8)
+            eb_threshold = 2**(-7)
+        if dtype in [torch.float32]:
+            precision_threshold = 2**(-12)
+            eb_threshold = 2**(-14)
+    if op_type in [OpTypes.CV_FUSION]:
+        precision_threshold = 522 #最大相对误差5/平均相对误差2/均方根误差2
+        if dtype in [torch.float16]:
+            eb_threshold = 2**(-10)
+        if dtype in [torch.bfloat16]:
+            eb_threshold = 2**(-7)
+        if dtype in [torch.float32]:
+            eb_threshold = 2**(-14)
+    logging.debug(f"op_type: {op_type}, dtype: {dtype}, precision_threshold: {precision_threshold}, eb_threshold: {eb_threshold}")
+    return precision_threshold, eb_threshold
+
+def precision_performance_analysis(op_type,golden_output_tensor_list,output_tensor_list,rtol: float):
+    for i in range(len(golden_output_tensor_list)):
+        actual_output = output_tensor_list[i].cpu()
+        golden_output = golden_output_tensor_list[i]
+        precision_threshold, eb_threshold = get_precision_and_eb_threshold(op_type, actual_output.dtype, rtol)
+        precision, eb = cal_precision_eb_percent(op_type,i, actual_output, golden_output, precision_threshold, eb_threshold)
+    if precision == 100 and eb <= 100:
+        return True
+    else:
+        print(f"precision: {precision}, eb: {eb}")
+        return False
+
+
+def cal_precision_eb_percent(op_type,i, actual_output, golden_output, precision_threshold, eb_threshold):
+    actual_output = actual_output if actual_output.dtype != torch.bool else actual_output.long()
+    golden_output = golden_output if golden_output.dtype != torch.bool else golden_output.long()
+    if op_type in [OpTypes.COMPUTE_FLOAT, OpTypes.COMPUTE_FLOAT_HIGH_PRECISION, OpTypes.VECTOR_FUSION] and actual_output.dtype in [torch.float16, torch.bfloat16]:
+        actual_output = actual_output.to(torch.float32)
+        golden_output = golden_output.to(torch.float32)
+    #对于输出中出现的NAN以及INF全部替换成0
+    actual_output = torch.where(torch.isnan(actual_output), torch.full_like(actual_output, 0), actual_output)
+    actual_output = torch.where(torch.isinf(actual_output), torch.full_like(actual_output, 0), actual_output)
+    golden_output = torch.where(torch.isnan(golden_output), torch.full_like(golden_output, 0), golden_output)
+    golden_output = torch.where(torch.isinf(golden_output), torch.full_like(golden_output, 0), golden_output)
+    if op_type == OpTypes.RAND:
+        alpha = 0.01
+        t_statistic, p_value = scipy.stats.ks_2samp(actual_output, golden_output)
+        precision_percent = 100 if p_value > alpha else 0
+        eb_percent = 0
+        return precision_percent, eb_percent
+    diff = torch.subtract(actual_output, golden_output)
+    tensor_max = torch.maximum(torch.ones(golden_output.shape, dtype=golden_output.dtype), torch.abs(golden_output))
+    if precision_threshold == 1:
+        tolerance = torch.subtract(torch.abs(diff), torch.ones(diff.shape, dtype=diff.dtype))
+    else:
+        tolerance = torch.subtract(torch.abs(diff), precision_threshold * tensor_max)
+    # eb 统计误差偏移情况
+    eb = eb_threshold
+    if eb_threshold != 0:
+        eb = torch.abs(torch.mean(torch.div(diff, tensor_max)))
+    precision_percent = torch.sum(tolerance <= 0).numpy() / torch.numel(tolerance) * 100
+    eb_percent = 0 if eb == 0 else torch.sum(eb).to(torch.float).numpy() / eb_threshold * 100
+    return precision_percent, eb_percent
+
+def verify_result():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output', type=str)
+    parser.add_argument('golden', type=str)
+    parser.add_argument('out_dtype', type=DataType.from_str, choices=[DataType.FLOAT16, DataType.BF16])
+    parser.add_argument('m', type=int)
+    parser.add_argument('n', type=int)
+    parser.add_argument('k', type=int)
+    args = parser.parse_args()
+
+    output = tensor_from_file(args.output, dtype=args.out_dtype.torch_type)
+    golden = tensor_from_file(args.golden, dtype=torch.float32)
+
+    rtol = get_rtol(dtype=args.out_dtype.torch_type, compute_times=args.k)
+    result = precision_performance_analysis(OpTypes.COMPUTE_FLOAT,[golden],[output], rtol)
+    return result
+
+import traceback
+
+if __name__ == '__main__':
+    try:
+        res = verify_result()
+        if not res:
+            print(f"{RED}ERROR{RESET}")
+        else:
+            print(f"{GREEN}PASS{RESET}")
+    except Exception as e:
+        print(e)
+        traceback.print_exc()
+        sys.exit(1)

--- a/include/catcoc/dgemm/kernel/quant_matmul_reduce_scatter.hpp
+++ b/include/catcoc/dgemm/kernel/quant_matmul_reduce_scatter.hpp
@@ -1,0 +1,360 @@
+#ifndef CATCOC_DGEMM_KERNEL_QUANT_MATMUL_REDUCE_SCATTER_HPP
+#define CATCOC_DGEMM_KERNEL_QUANT_MATMUL_REDUCE_SCATTER_HPP
+
+#include "catcoc/catcoc.hpp"
+
+// from catlass
+#include "catlass/arch/resource.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+
+namespace Catcoc::DGemm::Kernel {
+
+using Catlass::MatrixCoord;
+using Catlass::GemmCoord;
+
+template <
+    class BlockMmad_,
+    class BlockEpilogueReduceScatter_,
+    class BlockScheduler_,
+    class BlockEpilogueScheduler_,
+    uint32_t WORKSPACE_STAGES_
+>
+class QuantMatmulReduceScatter {
+public:
+    using BlockMmad = BlockMmad_;
+    using ArchTag = typename BlockMmad::ArchTag;
+    using L1TileShape = typename BlockMmad::L1TileShape;
+    using ElementA = typename BlockMmad::ElementA;
+    using LayoutA = typename BlockMmad::LayoutA;
+    using ElementB = typename BlockMmad::ElementB;
+    using LayoutB = typename BlockMmad::LayoutB;
+    using ElementC = typename BlockMmad::ElementC; // int32_t accumulator
+    using LayoutC = typename BlockMmad::LayoutC;
+
+    using ReduceScatter = BlockEpilogueReduceScatter_;
+    using ReduceScatterParams = typename ReduceScatter::Params;
+
+    using ElementD = bfloat16; // Final output type
+    using LayoutD = Catlass::layout::RowMajor;
+
+    using BlockScheduler = BlockScheduler_;
+    using CommScheduler = BlockEpilogueScheduler_;
+
+    static constexpr uint32_t WORKSPACE_STAGES = WORKSPACE_STAGES_;
+
+    /// Parameters structure
+    struct Params {
+        // Data members
+        GemmCoord problemShape;
+
+        uint32_t rankIdx;
+        uint32_t rankSize;
+
+        GM_ADDR ptrA; // int8
+        LayoutA layoutA;
+        GM_ADDR ptrB; // int8
+        LayoutB layoutB;
+        GM_ADDR ptrSymmetric;
+        ReduceScatterParams reduceScatterParams;
+
+        GM_ADDR ptrC_accum; // int32
+        LayoutC layoutC_accum;
+
+        GM_ADDR ptrD_out; // bfloat16
+        LayoutD layoutD_out;
+
+        GM_ADDR ptrScaleX1; // float
+        LayoutA layoutScaleX1; // Assuming RowMajor-like layout for vector
+        GM_ADDR ptrScaleX2; // float
+        LayoutA layoutScaleX2;
+        GM_ADDR ptrBias; // int32
+        LayoutA layoutBias;
+
+        uint32_t commInterval;
+
+        // Methods
+        CATLASS_DEVICE
+        Params() {}
+
+        CATLASS_DEVICE
+        Params(
+            GemmCoord const &problemShape_,
+            uint32_t rank_, uint32_t rankSize_,
+            GM_ADDR ptrA_, LayoutA const &layoutA_,
+            GM_ADDR ptrB_, LayoutB const &layoutB_,
+            GM_ADDR ptrSymmetric_,
+            ReduceScatterParams const &reduceScatterParams_,
+            GM_ADDR ptrC_accum_, LayoutC const &layoutC_accum_,
+            GM_ADDR ptrD_out_, LayoutD const &layoutD_out_,
+            GM_ADDR ptrScaleX1_, LayoutA const &layoutScaleX1_,
+            GM_ADDR ptrScaleX2_, LayoutA const &layoutScaleX2_,
+            GM_ADDR ptrBias_, LayoutA const &layoutBias_,
+            uint32_t commInterval_
+        ) : problemShape(problemShape_),
+            rankIdx(rank_), rankSize(rankSize_),
+            ptrA(ptrA_), layoutA(layoutA_),
+            ptrB(ptrB_), layoutB(layoutB_),
+            ptrSymmetric(ptrSymmetric_),
+            reduceScatterParams(reduceScatterParams_),
+            ptrC_accum(ptrC_accum_), layoutC_accum(layoutC_accum_),
+            ptrD_out(ptrD_out_), layoutD_out(layoutD_out_),
+            ptrScaleX1(ptrScaleX1_), layoutScaleX1(layoutScaleX1_),
+            ptrScaleX2(ptrScaleX2_), layoutScaleX2(layoutScaleX2_),
+            ptrBias(ptrBias_), layoutBias(layoutBias_),
+            commInterval(commInterval_) {}
+    };
+
+    // Methods
+    CATLASS_DEVICE
+    QuantMatmulReduceScatter()
+    {
+        for (uint32_t i = 0; i < WORKSPACE_STAGES; ++i) {
+            flagAicFinishStore[i] = Catlass::Arch::CrossCoreFlag(i);
+            flagAivFinishCompute[i] = Catlass::Arch::CrossCoreFlag(i);
+        }
+    }
+
+    template <int32_t CORE_TYPE = g_coreType>
+    CATLASS_DEVICE
+    void operator()(Params &params);
+
+    template <>
+    CATLASS_DEVICE
+    void operator()<AscendC::AIC>(Params &params)
+    {
+        uint32_t aicoreIndex = AscendC::GetBlockIdx();
+        uint32_t aicoreNum = AscendC::GetBlockNum();
+        uint32_t blockPerComm = aicoreNum * params.commInterval;
+        uint32_t blockPerCommInRank = blockPerComm / params.rankSize;
+
+        GemmCoord blockShape = L1TileShape::ToCoord();
+        GemmCoord problemShapeInRank = params.problemShape / Catlass::MakeCoord<uint32_t>(params.rankSize, 1, 1);
+        BlockScheduler matmulBlockScheduler(problemShapeInRank, blockShape.GetCoordMN());
+        uint32_t coreLoops = matmulBlockScheduler.GetCoreLoops() * params.rankSize;
+        uint32_t commLoops = CeilDiv(coreLoops, blockPerComm);
+
+        BlockMmad blockMmad(resource);
+
+        // Represent the full gm
+        AscendC::GlobalTensor<ElementA> gmA;
+        gmA.SetGlobalBuffer(reinterpret_cast<__gm__ ElementA *>(params.ptrA));
+        AscendC::GlobalTensor<ElementB> gmB;
+        gmB.SetGlobalBuffer(reinterpret_cast<__gm__ ElementB *>(params.ptrB));
+        AscendC::GlobalTensor<ElementC> gmC_workspace;
+        gmC_workspace.SetGlobalBuffer(reinterpret_cast<__gm__ ElementC *>(params.ptrSymmetric));
+        AscendC::GlobalTensor<ElementC> gmC_accum;
+        gmC_accum.SetGlobalBuffer(reinterpret_cast<__gm__ ElementC *>(params.ptrC_accum));
+
+        auto layoutC = Catlass::layout::RowMajor{
+            WORKSPACE_STAGES * blockPerComm * L1TileShape::M, L1TileShape::N,
+            L1TileShape::N
+        };
+
+        auto layoutCRowLogicShape = Catlass::MakeCoord<int>(WORKSPACE_STAGES, blockPerComm, L1TileShape::M);
+        auto layoutCRow = layout::AffineRankN<3>::Packed(layoutCRowLogicShape);
+
+        for (uint32_t commIdx = 0; commIdx < commLoops; ++commIdx) {
+            uint32_t stageId = commIdx % WORKSPACE_STAGES;
+
+            if (commIdx >= WORKSPACE_STAGES) {
+                Catlass::Arch::CrossCoreWaitFlag(flagAivFinishCompute[stageId]);
+            }
+
+            uint32_t actualBlockPerComm = (commIdx == commLoops - 1) ?
+                (coreLoops - blockPerComm * commIdx) : blockPerComm;
+            uint32_t actualBlockPerCommInRank = actualBlockPerComm / params.rankSize;
+
+            uint32_t commBlockOffsetInRank = commIdx * blockPerCommInRank;
+            for (
+                uint32_t blockIdxInComm = aicoreIndex;
+                blockIdxInComm < actualBlockPerComm;
+                blockIdxInComm += aicoreNum
+            ) {
+                uint32_t loopIdxInRank = commBlockOffsetInRank + blockIdxInComm % actualBlockPerCommInRank;
+                uint32_t targetRankIdx = blockIdxInComm / actualBlockPerCommInRank;
+                // Compute block location
+                GemmCoord blockCoord = matmulBlockScheduler.GetBlockCoord(loopIdxInRank);
+                GemmCoord actualBlockShape = matmulBlockScheduler.GetActualBlockShape(blockCoord);
+
+                GemmCoord offsetCoord = blockCoord * blockShape;
+                // Compute initial location in logical coordinates
+                auto rankOffsetA = problemShapeInRank.GetCoordMK() * Catlass::MakeCoord<uint32_t>(targetRankIdx, 0);
+                auto blockOffsetA = offsetCoord.GetCoordMK() + rankOffsetA;
+                auto blockOffsetB = offsetCoord.GetCoordKN();
+
+                MatrixCoord blockOffsetStore;
+                AscendC::GlobalTensor<ElementC> gmStore;
+                Catlass::layout::RowMajor layoutStore;
+                if (targetRankIdx == params.rankIdx) {
+                    blockOffsetStore = offsetCoord.GetCoordMN();
+                    gmStore = gmC_accum;
+                    layoutStore = params.layoutC_accum;
+                }
+                else {
+                    blockOffsetStore = MatrixCoord{layoutCRow(Catlass::MakeCoord<int>(stageId, blockIdxInComm, 0)), 0};
+                    gmStore = gmC_workspace;
+                    layoutStore = layoutC;
+                }
+
+                int64_t offsetA = params.layoutA.GetOffset(blockOffsetA);
+                int64_t offsetB = params.layoutB.GetOffset(blockOffsetB);
+                int64_t offsetStore = layoutStore.GetOffset(blockOffsetStore);
+
+                // Compute block-scoped matrix multiply-add
+                blockMmad(
+                    gmA[offsetA], params.layoutA,
+                    gmB[offsetB], params.layoutB,
+                    gmStore[offsetStore], layoutStore,
+                    actualBlockShape
+                );
+            }
+
+            Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(flagAicFinishStore[stageId]);
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+
+    template <>
+    CATLASS_DEVICE
+    void operator()<AscendC::AIV>(Params &params)
+    {
+        uint32_t aicoreIndex = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
+        uint32_t aicoreNum = AscendC::GetBlockNum();
+        uint32_t aivIndex = AscendC::GetSubBlockIdx();
+        uint32_t blockPerComm = aicoreNum * params.commInterval;
+        uint32_t blockPerCommInRank = blockPerComm / params.rankSize;
+
+        MatrixCoord blockShapeMN = L1TileShape::ToCoordMN();
+        GemmCoord problemShapeInRank = params.problemShape / Catlass::MakeCoord<uint32_t>(params.rankSize, 1, 1);
+        BlockScheduler matmulBlockScheduler(problemShapeInRank, blockShapeMN);
+        uint32_t coreLoops = matmulBlockScheduler.GetCoreLoops() * params.rankSize;
+        auto commLoops = CeilDiv(coreLoops, blockPerComm);
+
+        ReduceScatter reduceScatter(resource, params.reduceScatterParams);
+
+        AscendC::GlobalTensor<ElementC> gmC_workspace;
+        gmC_workspace.SetGlobalBuffer(reinterpret_cast<__gm__ ElementC *>(params.ptrSymmetric));
+
+        AscendC::GlobalTensor<ElementC> gmC_accum;
+        gmC_accum.SetGlobalBuffer(reinterpret_cast<__gm__ ElementC *>(params.ptrC_accum));
+
+        MatrixCoord commBlockShape = params.reduceScatterParams.BlockShape();
+        MatrixCoord commCoreSplit = params.reduceScatterParams.CoreSplit();
+        MatrixCoord commShape = MatrixCoord{blockPerComm, 1} * blockShapeMN;
+        MatrixCoord dataLoopsMx = CeilDiv(commShape, commBlockShape);
+        uint32_t dLoopsInRank = CeilDiv(dataLoopsMx.row() * dataLoopsMx.column(), params.rankSize);
+        CommScheduler commScheduler(params.rankIdx, params.rankSize, commCoreSplit,
+                                    commShape, commBlockShape, dLoopsInRank);
+        MatrixCoord actualCommShapeInRank = commShape / Catlass::MakeCoord<uint32_t>(params.rankSize, 1);
+
+        auto layoutCommLogicShape = Catlass::MakeCoord<int>(1, dLoopsInRank, commBlockShape.row());
+        auto layoutComm = layout::AffineRankN<3>::Packed(layoutCommLogicShape);
+
+        for (uint32_t commIdx = 0; commIdx < commLoops; ++commIdx) {
+            uint32_t stageId = commIdx % WORKSPACE_STAGES;
+            if (commIdx == commLoops - 1) {
+                uint32_t actualBlockInComm = coreLoops - commIdx * blockPerComm;
+                commShape = MatrixCoord{actualBlockInComm, 1} * blockShapeMN;
+                dataLoopsMx = CeilDiv(commShape, commBlockShape);
+                dLoopsInRank = CeilDiv(dataLoopsMx.row() * dataLoopsMx.column(), params.rankSize);
+                commScheduler.Update(commShape, commBlockShape, dLoopsInRank);
+                layoutCommLogicShape = Catlass::MakeCoord<int>(1, dLoopsInRank, commBlockShape.row());
+                layoutComm = layout::AffineRankN<3>::Packed(layoutCommLogicShape);
+                actualCommShapeInRank = commShape / Catlass::MakeCoord<uint32_t>(params.rankSize, 1);
+            }
+            auto commAicoreNum = commScheduler.GetRealCore();
+            auto commCoreLoops = commScheduler.GetCoreLoop();
+
+            MatrixCoord stageOffset = MatrixCoord{stageId * blockPerComm, 0} * blockShapeMN;
+            MatrixCoord commOffsetInRank = MatrixCoord{commIdx * blockPerCommInRank, 0} * blockShapeMN;
+
+            // wait aic
+            Catlass::Arch::CrossCoreWaitFlag(flagAicFinishStore[stageId]);
+            shmemx_barrier_all_vec();
+
+            AscendC::SetAtomicAdd<ElementC>(); // AtomicAdd on int32
+            AscendC::PipeBarrier<PIPE_ALL>();
+            reduceScatter.AllocEventID();
+            if (aivIndex == 0 && aicoreIndex < commAicoreNum) {
+                for (uint32_t commLoopIdx = aicoreIndex; commLoopIdx < commCoreLoops; commLoopIdx += commAicoreNum) {
+                    MatrixCoord commBlockCoord = commScheduler.GetBlockIdx(commLoopIdx);
+                    MatrixCoord blockOffset = commScheduler.template GetBlockOffset<ReduceScatter::RemoteCopyMode,
+                        ReduceScatter::RemoteCopyDirect>(commBlockCoord, layoutComm);
+                    MatrixCoord actualCommBlockShape = commScheduler.template GetActualBlockShape<
+                        ReduceScatter::RemoteCopyMode, ReduceScatter::RemoteCopyDirect>(commBlockCoord, layoutComm);
+                    MatrixCoord blockOffsetInRank = blockOffset % actualCommShapeInRank;
+
+                    uint32_t remoteRankIdx = commBlockCoord.column();
+                    if (remoteRankIdx == params.rankIdx) {
+                        continue;
+                    }
+
+                    auto offsetIn = stageOffset + blockOffset;
+                    auto offsetOut = commOffsetInRank + blockOffsetInRank;
+
+                    auto globalLoopIdx = offsetOut.row() / blockShapeMN.row();
+
+                    reduceScatter(blockShapeMN, offsetOut, offsetIn, actualCommBlockShape,
+                        gmC_accum, params.layoutC_accum, globalLoopIdx, remoteRankIdx % params.rankSize);
+                }
+            }
+            reduceScatter.ReleaseEventID();
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
+            AscendC::SetAtomicNone();
+            AscendC::PipeBarrier<PIPE_ALL>();
+
+            // ReduceScatter is completed, waiting until tasks on all devices are complete.
+            shmemx_barrier_all_vec();
+
+            Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(flagAivFinishCompute[stageId]);
+        }
+
+        // Final Dequantization Step
+        AscendC::GlobalTensor<ElementD> gmD_out;
+        gmD_out.SetGlobalBuffer(reinterpret_cast<__gm__ ElementD *>(params.ptrD_out));
+        AscendC::GlobalTensor<float> gmScaleX1;
+        gmScaleX1.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(params.ptrScaleX1));
+        AscendC::GlobalTensor<float> gmScaleX2;
+        gmScaleX2.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(params.ptrScaleX2));
+        AscendC::GlobalTensor<int32_t> gmBias;
+        gmBias.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(params.ptrBias));
+
+        uint32_t M_per_rank = params.problemShape.m / params.rankSize;
+        uint32_t N = params.problemShape.n;
+        uint32_t M_global_offset = params.rankIdx * M_per_rank;
+
+        // Each core handles a portion of the dequantization
+        for (uint32_t i = aicoreIndex; i < M_per_rank * N; i += aicoreNum) {
+            uint32_t m_local = i / N;
+            uint32_t n_local = i % N;
+            uint32_t m_global = M_global_offset + m_local;
+
+            int64_t offset_accum = params.layoutC_accum.GetOffset({m_local, n_local});
+            int32_t accum_val = gmC_accum[offset_accum];
+
+            float scale1 = gmScaleX1[m_global];
+            float scale2 = gmScaleX2[n_local];
+            int32_t bias = gmBias[n_local];
+
+            float dequant_val = (static_cast<float>(accum_val) + static_cast<float>(bias)) * scale1 * scale2;
+
+            int64_t offset_out = params.layoutD_out.GetOffset({m_local, n_local});
+            gmD_out[offset_out] = static_cast<ElementD>(dequant_val);
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+private:
+    // ID used for inter-core synchronization
+    Catlass::Arch::CrossCoreFlag flagAicFinishStore[WORKSPACE_STAGES];
+    Catlass::Arch::CrossCoreFlag flagAivFinishCompute[WORKSPACE_STAGES];
+    Catlass::Arch::Resource<ArchTag> resource;
+};
+
+} // namespace Catcoc::Gemm::Kernel
+
+#endif // CATCOC_DGEMM_KERNEL_QUANT_MATMUL_REDUCE_SCATTER_HPP


### PR DESCRIPTION
This commit introduces the `quant_matmul_reduce_scatter` operator, a quantized version of the existing `matmul_reduce_scatter` operator, designed to run on Ascend NPUs.

The implementation follows the specifications outlined in `quantized_matmul_reduce_scatter_design.md`.

Key components of this implementation include:

1.  **Quantized Kernel (`quant_matmul_reduce_scatter.hpp`)**:
    *   A new kernel class `QuantMatmulReduceScatter` is implemented.
    *   It accepts `int8` inputs for matrices A and B, `float32` for scales, and an `int32` bias.
    *   The matrix multiplication is performed using `int8` inputs, accumulating to an intermediate `int32` tensor.
    *   The existing `reduce_scatter` communication logic is used to perform reduction on the `int32` accumulator across ranks.
    *   A final dequantization step is performed in a manual loop at the end of the kernel, which applies the scales and bias to produce the final `bfloat16` output. This approach was chosen to minimize changes to the complex communication epilogues.

2.  **Example Implementation (`quant_matmul_reduce_scatter.cpp`)**:
    *   A new example file is provided to demonstrate the usage of the quantized kernel.
    *   It handles the allocation and memory management for all required tensors, including the new quantized inputs (x1, x2, scales, bias) and the intermediate `int32` accumulator.

3.  **Verification Scripts**:
    *   `gen_quant_data.py`: A new script to generate test data, including `int8` inputs, scales, a bias tensor, and a `bfloat16` golden output file for verification.
    *   `verify_quant_result.py`: A script to verify the operator's output against the golden data (copied from the original, as the floating-point comparison logic is still applicable).
    *   `run_quant.sh`: A new run script to orchestrate the data generation, execution of the new operator, and verification.

4.  **Build System**:
    *   The `CMakeLists.txt` file has been updated to include a build target for the new `quant_matmul_reduce_scatter` executable.

Note: Due to sandbox limitations (missing Ascend CANN environment), this implementation has not been compiled or tested. The implementation is based on a thorough review of the design document and the existing codebase.